### PR TITLE
Test function results in files with CSS output

### DIFF
--- a/src/funcResult.js
+++ b/src/funcResult.js
@@ -49,32 +49,32 @@ function FuncResult(file, call, args) {
 FuncResult.prototype = {
   equals: function(result) {
     var message = 'Function: ' + this.call + ' does not equal ' + result + '.';
-    assert.equal(this.css, wrapFunction(result), message);
+    assert(this.css.indexOf(wrapFunction(result)) > -1, message);
   },
 
   doesNotEqual: function(result) {
     var message = 'Function: ' + this.call + ' equals ' + result + '.';
-    assert.notEqual(this.css, wrapFunction(result), message);
+    assert(this.css.indexOf(wrapFunction(result)) === -1, message);
   },
 
   isTrue: function() {
     var message = 'Function does not equal true.';
-    assert.equal(this.css, wrapFunction(true), message);
+    assert(this.css.indexOf(wrapFunction(true)) > -1, message);
   },
 
   isFalse: function() {
     var message = 'Function does not equal false.';
-    assert.equal(this.css, wrapFunction(false), message);
+    assert(this.css.indexOf(wrapFunction(false)) > -1, message);
   },
 
   isTruthy: function() {
     var message = 'Function is not truthy.';
-    assert.equal(this.truthyCss, wrapFunction(true), message);
+    assert(this.truthyCss.indexOf(wrapFunction(true)) > -1, message);
   },
 
   isFalsy: function() {
     var message = 'Function is not falsy.';
-    assert.equal(this.truthyCss, wrapFunction(false), message);
+    assert(this.truthyCss.indexOf(wrapFunction(false)) > -1, message);
   }
 };
 

--- a/test/funcResultTests.js
+++ b/test/funcResultTests.js
@@ -12,13 +12,13 @@ describe('FuncResult', function() {
   var funcFalseResult;
   var mockUtilities;
   var args = [5];
-  var file = '@function test($input) { @return 2 * $input }';
+  var file = '@function test($input) { @return 2 * $input };.foo{display:"block";}';
   var call = 'test';
   var argString = '5';
   var result = '10';
-  var wrappedResult = '.test{content:' + result + '}';
-  var wrappedTrueResult = '.test{content:true}';
-  var wrappedFalseResult = '.test{content:false}';
+  var wrappedResult = '.foo{display:"block";}.test{content:' + result + '}';
+  var wrappedTrueResult = '.foo{display:"block";}.test{content:true}';
+  var wrappedFalseResult = '.foo{display:"block";}.test{content:false}';
 
   beforeEach(function() {
     FuncResult = proxyquire('../src/funcResult', {


### PR DESCRIPTION
Thanks for this project. I just started setting up tests for a new project of mine and ran into an issue testing results of a function in a scss partial that contains actual CSS output. 

I took a cue from the `.indexOf` logic in `mixinResult.js` when picking an approach for a fix. If you would prefer another approach, let me know.
## How to Reproduce

**_partial.scss**

``` scss
@function contains($list, $item) {
  @if index($list, $item) { @return true; }
  @return false;
}

.foo {
  display: 'block';
}
```

**partial-test.js**

``` js
import path from 'path';
import assert from 'assert';
import Sassaby from 'sassaby';

describe('_partial.scss', () => {
  const file = path.resolve(__dirname, '../elegant-sass-things/_spacing.scss');
  const sassaby = new Sassaby(file);

  describe('contains', () => {
    it('should return true when item is in list', () => {
      sassaby.func('contains').calledWithArgs('(0 (1:2) 1 2 3 4 5 6)', '1').isTrue();
    });
  });
});
```

**Test Output**

``` sh
> mocha --compilers js:babel-core/register

  _partial.scss
    contains
      1) should return true when item is in list

  0 passing (28ms)
  1 failing

  1) _partial.scss contains should return true when item is in list:

      AssertionError: Function does not equal true.
      + expected - actual

      -.foo{display:'block'}.test{content:true}
      +.test{content:true}
```
