### PR TITLE
Bump to node-sass@^4.7.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "css": "^2.2.0",
     "cssmin": "^0.4.3",
     "mocha": "^2.2.5",
-    "node-sass": "^3.1.2"
+    "node-sass": "^4.7.2"
   },
   "devDependencies": {
     "proxyquire": "^1.5.0",

--- a/src/mixinResult.js
+++ b/src/mixinResult.js
@@ -142,8 +142,8 @@ MixinResult.prototype = {
     assert.notEqual(this.css, wrappedOutput, message);
   },
 
-  calls: function(mixin) {
-    var mixinCss = utilities.createCss(this.file, wrapMixin(this.type, mixin));
+  calls: function(mixin, type) {
+    var mixinCss = utilities.createCss(this.file, wrapMixin(type || this.type, mixin));
     var message = 'Could not find the output from ' + mixin + ' in mixin.';
     assert(this.css.indexOf(unwrapOutput(this.type, mixinCss)) > -1, message);
   },

--- a/test/integrationTests.js
+++ b/test/integrationTests.js
@@ -153,7 +153,7 @@ describe('sample.scss', function() {
     });
 
     it('should call the correct mixin', function() {
-      compiled.calls('appearance(none)');
+      compiled.calls('appearance(none)', 'included');
     });
   });
 


### PR DESCRIPTION
This provides a workaround to test case when an included mixin is called inside an standalone mixin.